### PR TITLE
Update README.md

### DIFF
--- a/public/README.md
+++ b/public/README.md
@@ -10,7 +10,7 @@ Visit the [Scheduled Upgrades](UPGRADES.md) page for details on current and upco
 - **Launch date**: 2022-03-10
 - **Current Gaia Version:** `v7.0.2` upgraded at height `9283650`
 - **Launch Gaia Version:** `release/v6.0.0`
-- **Genesis File:**  Zipped and included [in this repository](public-testnet/genesis.json.gz), unzip and verify with `shasum -a 256 genesis.json`
+- **Genesis File:**  Zipped and included [in this repository](https://github.com/hyphacoop/testnets/blob/add-theta-testnet/v7-theta/public-testnet/genesis.json.gz), unzip and verify with `shasum -a 256 genesis.json`
 - **Genesis sha256sum**: `522d7e5227ca35ec9bbee5ab3fe9d43b61752c6bdbb9e7996b38307d7362bb7e`
 
 ### Endpoints
@@ -106,7 +106,7 @@ Modify the script with the Gaia [release branch](https://github.com/cosmos/gaia/
 ##### CONFIGURATION ###
 
 export GAIA_BRANCH=v7.0.0
-export GENESIS_ZIPPED_URL=https://github.com/cosmos/testnets/raw/master/theta/public-testnet/genesis.json.gz
+export GENESIS_ZIPPED_URL=wget https://github.com/hyphacoop/testnets/raw/add-theta-testnet/v7-theta/public-testnet/genesis.json.gz
 export NODE_HOME=$HOME/.gaia
 export CHAIN_ID=theta-testnet-001
 export NODE_MONIKER=my-node # only really need to change this one


### PR DESCRIPTION
The prior link to the current genesis.json file is broken and leads to 404. I have replaced it with hyphacoop's genesis file which is also used in the hub's documentation here: https://hub.cosmos.network/main/hub-tutorials/join-testnet.html#configuration-setup  

https://github.com/hyphacoop/testnets/blob/add-theta-testnet/v7-theta/public-testnet/genesis.json.gz  --  Blob version, for documentation purposes found in line 13.

and 

https://github.com/hyphacoop/testnets/raw/add-theta-testnet/v7-theta/public-testnet/genesis.json.gz  --  Raw version, for use in the shell script in line 109.

This genesis file returns the correct checksum for me -- 522d7e5227ca35ec9bbee5ab3fe9d43b61752c6bdbb9e7996b38307d7362bb7e -- but please check for yourself.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺ 
v If adding a new genesis file, make sure you also 
v update the `latest` directory. This is so the SDK repo
v can always just link to `latest` in the docs :)
v    
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  --> 

* [ ] Duplicated new genesis file in `latest` directory
